### PR TITLE
removed redundant newline

### DIFF
--- a/src/FileLogger.cpp
+++ b/src/FileLogger.cpp
@@ -156,7 +156,7 @@ namespace logpp {
         }
 
         ofstream outStream(formatString("%s%d", _filename.c_str(), _numLogs), (changedLogNo ? ios_base::trunc : ios_base::app));
-        outStream << getLogBufferAsString() << endl;
+        outStream << getLogBufferAsString();
 
         clearStringStream(getLogBuffer());
     }


### PR DESCRIPTION
# Pull Request Title
Remove double newline for file logger which always printed an empty line into log files

## Brief Description
We use logMessage() to add os specific newline char and afterwards flush with the flushBuffer() function which also add a "endl". This resulted into a double newline.
